### PR TITLE
fix: Secondary_Cut instead of edition: secondary cut

### DIFF
--- a/labelling/movies/editions.yml
+++ b/labelling/movies/editions.yml
@@ -1,14 +1,11 @@
-external_templates:
-  - repo: templates/collection_type/Collectionless_Label
-
 collections:
-  # Assign the "edition: secondary" label to movies with multiple editions so
-  # that they can be excluded from certain collections.
+  # Assign the "Secondary_Cut" label to movies with multiple editions so that
+  # they can be excluded from certain collections. Formatting as "edition:
+  # secondary" does not appear to work for for some reason.
   "Edition: Secondary":
-    template:
-      - name: Edition label
-        edition: secondary
-        title_list:
+    plex_search:
+      any:
+        title:
           - Alien (1979) 001 2003 Director's cut
           - Alien (1979) 002 1990 Special Edition
           - Alien (1979) 003B
@@ -34,3 +31,6 @@ collections:
           - Star Wars 006 (1983) 2016
           - Star Wars 006 (1983) 2019
           - Sucker Punch (2011) 001B
+    item_label: "Secondary_Cut"
+    build_collection: false
+    sync_mode: sync

--- a/libraries/movies/charts.yml
+++ b/libraries/movies/charts.yml
@@ -9,5 +9,5 @@ collections:
         chart: popular
       - name: Smart Shared Chart
         sort: random
-        exclude_label: "edition: secondary"
+        exclude_label: "Secondary_Cut"
     summary: "The most popular movies right now as determined by IMDb users."

--- a/playlists/movie_charts.yml
+++ b/playlists/movie_charts.yml
@@ -11,7 +11,7 @@ playlists:
     sync_mode: sync
     file_poster: /config/assets/playlists/Empire's 100 Greatest Movies.png
     filter:
-      label.not: "edition: secondary"
+      label.not: "Secondary_Cut"
 
   IMDb Lowest Rated:
     imdb_chart: lowest_rated
@@ -19,7 +19,7 @@ playlists:
     sync_mode: sync
     file_poster: /config/assets/playlists/IMDb Lowest Rated.png
     filter:
-      label.not: "edition: secondary"
+      label.not: "Secondary_Cut"
 
   IMDb Popular:
     imdb_chart: popular_movies
@@ -28,7 +28,7 @@ playlists:
     sync_mode: sync
     file_poster: /config/assets/playlists/IMDb Popular.png
     filter:
-      label.not: "edition: secondary"
+      label.not: "Secondary_Cut"
 
   IMDb Top 250:
     imdb_chart: top_movies
@@ -36,7 +36,7 @@ playlists:
     sync_mode: sync
     file_poster: /config/assets/playlists/IMDb Top 250.png
     filter:
-      label.not: "edition: secondary"
+      label.not: "Secondary_Cut"
 
   Oscars Best Picture Winners:
     template:
@@ -47,4 +47,4 @@ playlists:
     sync_mode: sync
     file_poster: /config/assets/playlists/Oscars Best Picture Winners.png
     filter:
-      label.not: "edition: secondary"
+      label.not: "Secondary_Cut"

--- a/templates/collection_type/Collectionless_Label.yml
+++ b/templates/collection_type/Collectionless_Label.yml
@@ -15,14 +15,6 @@ templates:
     build_collection: false
     sync_mode: sync
 
-  Edition label:
-    plex_search:
-      any:
-        title: <<title_list>>
-    item_label: "edition: <<edition>>"
-    build_collection: false
-    sync_mode: sync
-
   Ownership label:
     plex_search:
       any:


### PR DESCRIPTION
Formatting as "edition: secondary" does not appear to work for some reason.